### PR TITLE
bugfix demo error

### DIFF
--- a/examples/filtertest_gum.html
+++ b/examples/filtertest_gum.html
@@ -115,7 +115,7 @@
 				};
 				
 				navigator.getUserMedia({video: true}, function( stream ) {
-					videoInput.src = window.URL.createObjectURL(stream);
+					videoInput.srcObject = stream;
 					videoInput.play();
 			    videoInput.addEventListener('canplay', enablestart, false);
 				}, function() {

--- a/examples/filtertest_gum_face.html
+++ b/examples/filtertest_gum_face.html
@@ -111,7 +111,7 @@
 				};
 				
 				navigator.getUserMedia({video: true}, function( stream ) {
-					videoInput.src = window.URL.createObjectURL(stream);
+					videoInput.srcObject = stream;
 					videoInput.play();
 					videoInput.addEventListener('canplay', enablestart, false);
 				}, function() {


### PR DESCRIPTION
The demo code reports error of "createObjectURL' on 'URL': Overload resolution failed." due to the older browser implementations of the getUserMedia API. Replace the createObjectURL() usage with srcObject.